### PR TITLE
feat: Enhance compliance evaluation to handle deleted log groups 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,6 +210,7 @@ __marimo__/
 .aws-sam/
 packaged-template.yaml
 template-sar.yaml
+packaged.yaml
 
 # Security scan reports
 bandit-report.json

--- a/cw-lg-retention-monitor/README.md
+++ b/cw-lg-retention-monitor/README.md
@@ -133,16 +133,18 @@ sam build && sam deploy --guided
 ### Rule Logic
 ```python
 if log_group.retentionInDays is None:
-    return "NON_COMPLIANT"  # ❌ Infinite retention = cost risk
+    return "NON_COMPLIANT"  # Infinite retention = cost risk
 elif log_group.retentionInDays < minimum_days:
-    return "NON_COMPLIANT"  # ❌ Below minimum retention period
+    return "NON_COMPLIANT"  # Below minimum retention period
 else:
-    return "COMPLIANT"      # ✅ Meets or exceeds minimum requirement
+    return "COMPLIANT"      # Meets or exceeds minimum requirement
+
+# Deleted resources marked as NOT_APPLICABLE
 ```
 
 ### Evaluation Schedule
-- **Periodic**: Every 24 hours (checks all log groups)
-- **Real-time**: When log groups are created/modified
+- **Periodic**: Every 24 hours (checks all log groups, marks deleted as NOT_APPLICABLE)
+- **Real-time**: When log groups are created/modified/deleted
 - **Manual**: Trigger via AWS Console or API
 
 ## 📊 Compliance Results
@@ -199,6 +201,8 @@ CloudWatch supports these retention periods:
 The Lambda function needs:
 - `logs:DescribeLogGroups` - List all log groups
 - `config:PutEvaluations` - Submit compliance results
+- `config:DescribeComplianceByConfigRule` - Query previous evaluations
+- `config:GetComplianceDetailsByConfigRule` - Get evaluation details
 
 ## 🏗️ Architecture
 
@@ -341,6 +345,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🔄 Version History
 
+- **v1.1.0** - Fixed stale evaluation handling for deleted resources
 - **v1.0.0** - Initial SAR release with core functionality
 - **v0.9.0** - RDK-based implementation (legacy)
 

--- a/cw-lg-retention-monitor/README.md
+++ b/cw-lg-retention-monitor/README.md
@@ -345,6 +345,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## 🔄 Version History
 
+- **v1.1.1** - Fixed Config rule deployment dependency issue
 - **v1.1.0** - Fixed stale evaluation handling for deleted resources
 - **v1.0.0** - Initial SAR release with core functionality
 - **v0.9.0** - RDK-based implementation (legacy)

--- a/cw-lg-retention-monitor/template.yaml
+++ b/cw-lg-retention-monitor/template.yaml
@@ -11,7 +11,7 @@ Metadata:
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     HomePageUrl: https://github.com/zsoftly/aws-config-rules
-    SemanticVersion: 1.1.0
+    SemanticVersion: 1.1.1
     SourceCodeUrl: https://github.com/zsoftly/aws-config-rules
     Labels: ['config', 'cloudwatch', 'logs', 'retention', 'compliance', 'cost-optimization']
 
@@ -101,6 +101,7 @@ Resources:
   # Config Rule
   LogRetentionConfigRule:
     Type: AWS::Config::ConfigRule
+    DependsOn: ConfigRuleInvokePermission
     Properties:
       ConfigRuleName: !Ref ConfigRuleName
       Description: !Sub |

--- a/cw-lg-retention-monitor/template.yaml
+++ b/cw-lg-retention-monitor/template.yaml
@@ -11,7 +11,7 @@ Metadata:
     LicenseUrl: LICENSE
     ReadmeUrl: README.md
     HomePageUrl: https://github.com/zsoftly/aws-config-rules
-    SemanticVersion: 1.0.2
+    SemanticVersion: 1.1.0
     SourceCodeUrl: https://github.com/zsoftly/aws-config-rules
     Labels: ['config', 'cloudwatch', 'logs', 'retention', 'compliance', 'cost-optimization']
 
@@ -70,6 +70,8 @@ Resources:
               - Effect: Allow
                 Action:
                   - config:PutEvaluations
+                  - config:DescribeComplianceByConfigRule
+                  - config:GetComplianceDetailsByConfigRule
                 Resource: '*'
 
   # Lambda Log Group (pre-created with retention)


### PR DESCRIPTION
## Description
Fixed stale evaluation handling for deleted resources and deployment dependency issue in CloudWatch LogGroup Retention Monitor

## Affected Config Rules
Which Config rules are impacted by this change?
  - CloudWatch LogGroup Retention Monitor (cw-lg-retention-monitor)
  - New Config Rule (specify name):
  - Repository infrastructure/CI changes
  - Documentation only

## Type of Change
  - Bug fix (non-breaking change that fixes an issue)
  - New feature (non-breaking change that adds functionality)
  - Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - New AWS Config Rule
  - Documentation update
  - CI/CD improvement

## Checklist
  - Tests pass (all affected rules)
  - Code coverage meets requirements (75%+)
  - SAM templates validate successfully
  - Documentation updated (README, SAR docs, etc.)
  - Breaking changes documented
  - SAR applications tested (if applicable)

## Testing
Describe how this was tested:

### Unit Tests
  - All existing tests pass
  - New tests added for new functionality
  - Code coverage: 95%

### Integration Testing
  - SAM template validation
  - Local deployment tested
  - SAR publication tested (if applicable)

### Manual Testing
  - Deployed version 1.1.1 to dev account via SAR
  - Verified Config rule evaluations work correctly
  - Confirmed deleted log groups marked as NOT_APPLICABLE
  - Tested re-evaluation clears stale compliance results

## Additional Notes
  Version 1.1.1 fixes two critical issues:

  1. Stale evaluation cleanup - Lambda now queries previous evaluations and marks deleted resources as NOT_APPLICABLE, preventing incorrect compliance counts in AWS Config dashboard
  2. Deployment dependency - Added DependsOn: ConfigRuleInvokePermission to Config rule resource to prevent deployment failures

  Changes:
  - Lambda function enhanced to track and report deleted resources
  - Added IAM permissions for Config API queries
  - Template fixed to ensure proper resource creation order
  - Added comprehensive test coverage (95%) for new functionality
  - Created check-config-setup.sh script for prerequisite verification