### PR TITLE
feat: Add upgrade guide and script for CloudWatch LogGroup Retention …

### DIFF
--- a/cw-lg-retention-monitor/README.md
+++ b/cw-lg-retention-monitor/README.md
@@ -116,6 +116,18 @@ After deploying this Config rule, enhance your log management with **LogGuardian
 | **ConfigRuleName** | `cw-lg-retention-min` | Name for the Config rule (must contain 'retention') |
 | **LambdaLogRetentionDays** | `7` | Retention period for Lambda function logs (1-3653 days) |
 
+## 🔄 Upgrading Existing Deployments
+
+See [UPGRADE.md](UPGRADE.md) for detailed instructions on upgrading your existing SAR deployment to the latest version.
+
+### Quick Upgrade
+```bash
+# Download and run upgrade script
+curl -O https://raw.githubusercontent.com/zsoftly/aws-config-rules/main/cw-lg-retention-monitor/scripts/upgrade-sar-stack.sh
+chmod +x upgrade-sar-stack.sh
+./upgrade-sar-stack.sh --version 1.1.1
+```
+
 ## 📦 Alternative Deployment Methods
 
 ### AWS SAM CLI (For Development)

--- a/cw-lg-retention-monitor/UPGRADE.md
+++ b/cw-lg-retention-monitor/UPGRADE.md
@@ -1,0 +1,206 @@
+# Upgrade Guide for CloudWatch LogGroup Retention Monitor
+
+This guide explains how to upgrade your existing SAR-deployed CloudWatch LogGroup Retention Monitor to the latest version.
+
+## Table of Contents
+- [Finding Your Current Version](#finding-your-current-version)
+- [Available Versions](#available-versions)
+- [Manual Upgrade Process](#manual-upgrade-process)
+- [Automated Upgrade Script](#automated-upgrade-script)
+- [Troubleshooting](#troubleshooting)
+
+## Finding Your Current Version
+
+**Note:** SAR version tags are unreliable and may show incorrect versions after updates. The upgrade script will use CloudFormation change sets to determine if actual updates are needed.
+
+### Via AWS Console
+1. Go to **CloudFormation** → Find your stack (usually `serverlessrepo-CloudWatch-LogGroup-Retention-Monitor`)
+2. Click **Stack info** tab → Look for tag `serverlessrepo:semanticVersion` (may be inaccurate)
+3. For actual update status, check Lambda function's **Last modified** timestamp
+
+### Via AWS CLI
+```bash
+# Check version tag (may be inaccurate)
+aws cloudformation describe-stacks \
+  --stack-name serverlessrepo-CloudWatch-LogGroup-Retention-Monitor \
+  --query "Stacks[0].Tags[?Key=='serverlessrepo:semanticVersion'].Value" \
+  --output text
+
+# Check Lambda last modified time (more reliable)
+LAMBDA_NAME=$(aws cloudformation describe-stack-resources \
+  --stack-name serverlessrepo-CloudWatch-LogGroup-Retention-Monitor \
+  --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" \
+  --output text | head -1)
+
+aws lambda get-function --function-name "$LAMBDA_NAME" \
+  --query "Configuration.LastModified" --output text
+```
+
+## Available Versions
+
+| Version | Release Date | Changes |
+|---------|-------------|---------|
+| 1.1.1 | 2025-08-22 | Fixed Config rule deployment dependency issue |
+| 1.1.0 | 2025-08-22 | Fixed stale evaluation handling for deleted resources |
+| 1.0.2 | 2025-08-20 | Minor bug fixes |
+| 1.0.1 | 2025-08-20 | Documentation updates |
+| 1.0.0 | 2025-08-20 | Initial release |
+
+## Manual Upgrade Process
+
+### Prerequisites
+- AWS CLI installed and configured
+- Appropriate IAM permissions for CloudFormation and SAR
+- Note your existing stack name and parameters
+
+### Step 1: Get Current Parameters
+```bash
+aws cloudformation describe-stacks \
+  --stack-name serverlessrepo-CloudWatch-LogGroup-Retention-Monitor \
+  --query "Stacks[0].Parameters"
+```
+
+### Step 2: Generate Template URL
+```bash
+aws serverlessrepo create-cloud-formation-template \
+  --application-id arn:aws:serverlessrepo:ca-central-1:410129828371:applications/CloudWatch-LogGroup-Retention-Monitor \
+  --semantic-version 1.1.1
+```
+
+Copy the `TemplateUrl` from the output.
+
+### Step 3: Update via CloudFormation Console
+1. Go to **CloudFormation Console**
+2. Select your stack (`serverlessrepo-CloudWatch-LogGroup-Retention-Monitor`)
+3. Click **Update**
+4. Select **Replace current template**
+5. Choose **Amazon S3 URL**
+6. Paste the `TemplateUrl` from Step 2
+7. Click **Next**
+8. Keep all existing parameter values
+9. Click **Next** → **Next** → **Update stack**
+
+### Step 4: Monitor Update
+```bash
+aws cloudformation wait stack-update-complete \
+  --stack-name serverlessrepo-CloudWatch-LogGroup-Retention-Monitor
+```
+
+## Automated Upgrade Script
+
+### Using the Upgrade Script
+
+1. Download the upgrade script:
+```bash
+curl -O https://raw.githubusercontent.com/zsoftly/aws-config-rules/main/cw-lg-retention-monitor/scripts/upgrade-sar-stack.sh
+chmod +x upgrade-sar-stack.sh
+```
+
+2. Run the upgrade:
+```bash
+# Upgrade to latest version
+./upgrade-sar-stack.sh
+
+# Upgrade to specific version
+./upgrade-sar-stack.sh --version 1.1.1
+
+# Specify stack name if different
+./upgrade-sar-stack.sh --stack-name my-custom-stack-name
+```
+
+### Script Options
+- `--version VERSION` - Specify version to upgrade to (default: latest)
+- `--stack-name NAME` - Stack name (default: serverlessrepo-CloudWatch-LogGroup-Retention-Monitor)
+- `--region REGION` - AWS region (default: current region)
+- `--profile PROFILE` - AWS profile to use
+- `--help` - Show help message
+
+## Alternative: Delete and Redeploy
+
+If the update process fails, you can delete and redeploy:
+
+### Step 1: Delete Existing Stack
+```bash
+aws cloudformation delete-stack \
+  --stack-name serverlessrepo-CloudWatch-LogGroup-Retention-Monitor
+
+aws cloudformation wait stack-delete-complete \
+  --stack-name serverlessrepo-CloudWatch-LogGroup-Retention-Monitor
+```
+
+### Step 2: Deploy New Version
+```bash
+aws serverlessrepo create-cloud-formation-change-set \
+  --application-id arn:aws:serverlessrepo:ca-central-1:410129828371:applications/CloudWatch-LogGroup-Retention-Monitor \
+  --stack-name serverlessrepo-CloudWatch-LogGroup-Retention-Monitor \
+  --semantic-version 1.1.1 \
+  --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND CAPABILITY_RESOURCE_POLICY \
+  --parameter-overrides \
+    Name=MinimumRetentionDays,Value=1 \
+    Name=ConfigRuleName,Value=cw-lg-retention-min \
+    Name=LambdaLogRetentionDays,Value=7
+```
+
+### Step 3: Execute Change Set
+```bash
+# Get change set ARN from previous command output
+aws cloudformation execute-change-set --change-set-name <CHANGE_SET_ARN>
+```
+
+## Troubleshooting
+
+### Common Issues
+
+#### Template URL Expired
+**Error**: `The specified S3 URL has expired`  
+**Solution**: Template URLs expire after 6 hours. Generate a new URL and retry immediately.
+
+#### Stack in UPDATE_ROLLBACK_FAILED
+**Solution**: 
+```bash
+aws cloudformation continue-update-rollback \
+  --stack-name serverlessrepo-CloudWatch-LogGroup-Retention-Monitor
+```
+
+#### Insufficient Permissions
+**Error**: `User is not authorized to perform: serverlessrepo:CreateCloudFormationTemplate`  
+**Solution**: Ensure your IAM role has the following permissions:
+- `serverlessrepo:CreateCloudFormationTemplate`
+- `cloudformation:UpdateStack`
+- `cloudformation:CreateChangeSet`
+- `cloudformation:ExecuteChangeSet`
+
+### Verify Upgrade Success
+
+1. Check stack status:
+```bash
+aws cloudformation describe-stacks \
+  --stack-name serverlessrepo-CloudWatch-LogGroup-Retention-Monitor \
+  --query "Stacks[0].StackStatus"
+```
+
+2. Verify Config rule is working:
+```bash
+aws configservice start-config-rules-evaluation \
+  --config-rule-names cw-lg-retention-min
+```
+
+3. Check Lambda function update:
+```bash
+aws lambda get-function \
+  --function-name cw-lg-retention-min-function \
+  --query "Configuration.LastModified"
+```
+
+## Support
+
+For issues or questions:
+- GitHub Issues: https://github.com/zsoftly/aws-config-rules/issues
+- Documentation: https://github.com/zsoftly/aws-config-rules
+
+## Important Notes
+
+- **Backup**: While Config rules don't store data, note your current parameters before upgrading
+- **Testing**: Test upgrades in a development environment first
+- **Timing**: Template URLs expire in 6 hours - complete the upgrade promptly
+- **Rollback**: CloudFormation automatically rolls back failed updates

--- a/cw-lg-retention-monitor/scripts/upgrade-sar-stack.sh
+++ b/cw-lg-retention-monitor/scripts/upgrade-sar-stack.sh
@@ -1,0 +1,328 @@
+#!/bin/bash
+
+# CloudWatch LogGroup Retention Monitor - SAR Stack Upgrade Script
+# Simplified version that doesn't rely on unreliable SAR version tags
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Default values
+APPLICATION_ID="arn:aws:serverlessrepo:ca-central-1:410129828371:applications/CloudWatch-LogGroup-Retention-Monitor"
+DEFAULT_STACK_NAME="serverlessrepo-CloudWatch-LogGroup-Retention-Monitor"
+STACK_NAME=""
+VERSION="latest"
+REGION=""
+PROFILE=""
+
+# Function to print colored output
+print_info() {
+    echo -e "${BLUE}[INFO]${NC} $1"
+}
+
+print_success() {
+    echo -e "${GREEN}[SUCCESS]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+# Function to show usage
+show_usage() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Upgrade SAR-deployed CloudWatch LogGroup Retention Monitor to a new version.
+
+OPTIONS:
+    --stack-name NAME     Stack name (default: $DEFAULT_STACK_NAME)
+    --version VERSION     Version to upgrade to (default: latest)
+    --region REGION       AWS region (default: current region)
+    --profile PROFILE     AWS profile to use
+    --help               Show this help message
+
+EXAMPLES:
+    # Upgrade to latest version
+    $0
+
+    # Upgrade to specific version
+    $0 --version 1.1.1
+
+    # Use custom stack name
+    $0 --stack-name my-custom-stack --version 1.1.1
+
+EOF
+    exit 0
+}
+
+# Parse command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --stack-name)
+            STACK_NAME="$2"
+            shift 2
+            ;;
+        --version)
+            VERSION="$2"
+            shift 2
+            ;;
+        --region)
+            REGION="$2"
+            shift 2
+            ;;
+        --profile)
+            PROFILE="$2"
+            shift 2
+            ;;
+        --help)
+            show_usage
+            ;;
+        *)
+            print_error "Unknown option: $1"
+            show_usage
+            ;;
+    esac
+done
+
+# Set AWS CLI options
+AWS_OPTS=""
+if [ -n "$PROFILE" ]; then
+    AWS_OPTS="$AWS_OPTS --profile $PROFILE"
+fi
+if [ -n "$REGION" ]; then
+    AWS_OPTS="$AWS_OPTS --region $REGION"
+else
+    REGION=$(aws configure get region $AWS_OPTS || echo "us-east-1")
+    AWS_OPTS="$AWS_OPTS --region $REGION"
+fi
+
+# Use default stack name if not provided
+if [ -z "$STACK_NAME" ]; then
+    STACK_NAME="$DEFAULT_STACK_NAME"
+fi
+
+echo "========================================="
+echo "SAR Stack Upgrade Tool"
+echo "========================================="
+echo ""
+print_info "Stack Name: $STACK_NAME"
+print_info "Region: $REGION"
+
+# Check if AWS CLI is installed
+if ! command -v aws &> /dev/null; then
+    print_error "AWS CLI is not installed"
+    echo "Please install AWS CLI: https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html"
+    exit 1
+fi
+
+# Check AWS credentials
+if ! aws sts get-caller-identity $AWS_OPTS &> /dev/null; then
+    print_error "AWS credentials not configured or invalid"
+    echo "Please configure AWS credentials: aws configure"
+    exit 1
+fi
+
+# Check if stack exists
+print_info "Checking if stack exists..."
+if ! aws cloudformation describe-stacks --stack-name "$STACK_NAME" $AWS_OPTS &> /dev/null; then
+    print_error "Stack '$STACK_NAME' not found"
+    echo "Please check the stack name and try again"
+    exit 1
+fi
+
+# Get target version first
+if [ "$VERSION" == "latest" ]; then
+    print_info "Getting latest available version..."
+    VERSION=$(aws serverlessrepo list-application-versions \
+        --application-id "$APPLICATION_ID" \
+        --query "Versions | sort_by(@, &CreationTime) | [-1].SemanticVersion" \
+        --output text $AWS_OPTS)
+    print_info "Latest version available: $VERSION"
+else
+    print_info "Target version: $VERSION"
+fi
+
+# Get Lambda info for comparison
+LAMBDA_NAME=$(aws cloudformation describe-stack-resources \
+    --stack-name "$STACK_NAME" \
+    --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" \
+    --output text $AWS_OPTS | head -1)
+
+if [ -n "$LAMBDA_NAME" ]; then
+    LAMBDA_UPDATE=$(aws lambda get-function \
+        --function-name "$LAMBDA_NAME" \
+        --query "Configuration.LastModified" \
+        --output text $AWS_OPTS 2>/dev/null)
+    
+    print_info "Current Lambda last modified: $LAMBDA_UPDATE"
+fi
+
+# Get current parameters for the upgrade
+CURRENT_PARAMS=$(aws cloudformation describe-stacks \
+    --stack-name "$STACK_NAME" \
+    --query "Stacks[0].Parameters" \
+    --output json $AWS_OPTS)
+
+# Generate template URL for target version
+print_info "Checking for differences between current and target version $VERSION..."
+print_info "Generating template URL for version $VERSION..."
+TEMPLATE_RESPONSE=$(aws serverlessrepo create-cloud-formation-template \
+    --application-id "$APPLICATION_ID" \
+    --semantic-version "$VERSION" \
+    --output json $AWS_OPTS)
+
+TEMPLATE_URL=$(echo "$TEMPLATE_RESPONSE" | grep -o '"TemplateUrl": "[^"]*"' | cut -d'"' -f4)
+
+if [ -z "$TEMPLATE_URL" ]; then
+    print_error "Failed to generate template URL"
+    exit 1
+fi
+
+print_success "Template URL generated"
+
+# Create change set to check if update is needed
+CHANGE_SET_NAME="Upgrade$(echo "$VERSION" | tr '.' '-')-$(date +%s)"
+print_info "Creating change set to check for updates..."
+
+CHANGE_SET_PARAMS=""
+for param in $(echo "$CURRENT_PARAMS" | jq -r '.[] | .ParameterKey'); do
+    CHANGE_SET_PARAMS="$CHANGE_SET_PARAMS ParameterKey=$param,UsePreviousValue=true"
+done
+
+# Create change set
+CHANGE_SET_OUTPUT=$(aws cloudformation create-change-set \
+    --stack-name "$STACK_NAME" \
+    --change-set-name "$CHANGE_SET_NAME" \
+    --template-url "$TEMPLATE_URL" \
+    --capabilities CAPABILITY_IAM CAPABILITY_AUTO_EXPAND \
+    --parameters $CHANGE_SET_PARAMS \
+    --output json $AWS_OPTS 2>&1)
+
+if [ $? -ne 0 ]; then
+    print_error "Failed to create change set"
+    echo "$CHANGE_SET_OUTPUT"
+    exit 1
+fi
+
+CHANGE_SET_ARN=$(echo "$CHANGE_SET_OUTPUT" | grep -o '"Id": "[^"]*"' | cut -d'"' -f4)
+
+# Wait for change set
+print_info "Checking for required updates..."
+sleep 3
+
+# Check change set status
+CHANGE_SET_STATUS=$(aws cloudformation describe-change-set \
+    --stack-name "$STACK_NAME" \
+    --change-set-name "$CHANGE_SET_NAME" \
+    --query "Status" \
+    --output text $AWS_OPTS 2>/dev/null)
+
+if [ "$CHANGE_SET_STATUS" == "FAILED" ]; then
+    STATUS_REASON=$(aws cloudformation describe-change-set \
+        --stack-name "$STACK_NAME" \
+        --change-set-name "$CHANGE_SET_NAME" \
+        --query "StatusReason" \
+        --output text $AWS_OPTS)
+    
+    if echo "$STATUS_REASON" | grep -qi "no updates\|didn't contain changes"; then
+        print_success "No changes needed - stack is already up to date with version $VERSION"
+        
+        if [ -n "$LAMBDA_UPDATE" ]; then
+            print_info "Lambda last modified: $LAMBDA_UPDATE"
+        fi
+        
+        # Clean up
+        aws cloudformation delete-change-set \
+            --stack-name "$STACK_NAME" \
+            --change-set-name "$CHANGE_SET_NAME" $AWS_OPTS 2>/dev/null
+        
+        exit 0
+    else
+        print_error "Change set failed: $STATUS_REASON"
+        aws cloudformation delete-change-set \
+            --stack-name "$STACK_NAME" \
+            --change-set-name "$CHANGE_SET_NAME" $AWS_OPTS 2>/dev/null
+        exit 1
+    fi
+fi
+
+# Wait for change set to be ready
+aws cloudformation wait change-set-create-complete \
+    --stack-name "$STACK_NAME" \
+    --change-set-name "$CHANGE_SET_NAME" $AWS_OPTS 2>/dev/null
+
+# Display changes
+print_info "Changes to be applied:"
+aws cloudformation describe-change-set \
+    --stack-name "$STACK_NAME" \
+    --change-set-name "$CHANGE_SET_NAME" \
+    --query "Changes[*].{Action:ResourceChange.Action,Resource:ResourceChange.LogicalResourceId,Type:ResourceChange.ResourceType}" \
+    --output table $AWS_OPTS
+
+# Confirm execution
+echo ""
+read -p "Do you want to apply these changes? (y/N): " -n 1 -r
+echo ""
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    print_warning "Upgrade cancelled"
+    aws cloudformation delete-change-set \
+        --stack-name "$STACK_NAME" \
+        --change-set-name "$CHANGE_SET_NAME" $AWS_OPTS 2>/dev/null
+    exit 0
+fi
+
+# Execute change set
+print_info "Applying changes..."
+aws cloudformation execute-change-set \
+    --stack-name "$STACK_NAME" \
+    --change-set-name "$CHANGE_SET_NAME" $AWS_OPTS
+
+# Wait for update
+print_info "Waiting for stack update to complete (this may take several minutes)..."
+if aws cloudformation wait stack-update-complete \
+    --stack-name "$STACK_NAME" $AWS_OPTS; then
+    print_success "Stack successfully upgraded to version $VERSION"
+    
+    # Show Lambda update time
+    LAMBDA_NAME=$(aws cloudformation describe-stack-resources \
+        --stack-name "$STACK_NAME" \
+        --query "StackResources[?ResourceType=='AWS::Lambda::Function'].PhysicalResourceId" \
+        --output text $AWS_OPTS | head -1)
+    
+    if [ -n "$LAMBDA_NAME" ]; then
+        LAMBDA_UPDATE=$(aws lambda get-function \
+            --function-name "$LAMBDA_NAME" \
+            --query "Configuration.LastModified" \
+            --output text $AWS_OPTS 2>/dev/null)
+        print_info "Lambda updated: $LAMBDA_UPDATE"
+    fi
+    
+    # Trigger evaluation
+    CONFIG_RULE=$(aws cloudformation describe-stack-resources \
+        --stack-name "$STACK_NAME" \
+        --query "StackResources[?ResourceType=='AWS::Config::ConfigRule'].PhysicalResourceId" \
+        --output text $AWS_OPTS | head -1)
+    
+    if [ -n "$CONFIG_RULE" ]; then
+        aws configservice start-config-rules-evaluation \
+            --config-rule-names "$CONFIG_RULE" $AWS_OPTS 2>/dev/null && \
+        print_success "Config rule evaluation triggered"
+    fi
+else
+    print_error "Stack update failed or was rolled back"
+    echo "Check CloudFormation console for details"
+    exit 1
+fi
+
+echo ""
+print_success "Upgrade complete!"


### PR DESCRIPTION
## Description
Added upgrade documentation and automated script for SAR deployments.

## Affected Config Rules
  - CloudWatch LogGroup Retention Monitor (cw-lg-retention-monitor)

## Type of Change
  - Documentation update

## Checklist
  - Documentation updated (README, UPGRADE.md)

## Testing
Describe how this was tested:

### Unit Tests
  - Tested upgrade script with SAR deployments
  - Verified script handles version detection correctly
  - Confirmed CloudFormation change sets work as expected

### Manual Testing
  - Tested upgrade script with SAR deployments
  - Verified script handles version detection correctly
  - Confirmed CloudFormation change sets work as expected

## Additional Notes
SAR version tags are unreliable - script uses change sets to determine if updates needed.